### PR TITLE
use ci-build-wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,61 @@ jobs:
           name: mm-test-adapters-${{ runner.os }}-${{ runner.arch }}
           path: mm-test-adapters-${{ runner.os }}-${{ runner.arch }}.zip
 
+  build-sdist:
+    runs-on: ubuntu-latest
+    env:
+      MM_SHA: ${{ github.event.inputs.submodule_sha || 'main' }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: hynek/build-and-inspect-python-package@v2
+        with:
+          skip-wheel: true
+
+  build-wheels:
+    name: ${{ matrix.os }} wheel
+    runs-on: ${{ matrix.os }}
+    env:
+      MM_SHA: ${{ github.event.inputs.submodule_sha || 'main' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+    steps:
+      - uses: actions/checkout@5
+      - uses: astral-sh/setup-uv@v6
+      - name: Build wheels via cibuildwheel
+        uses: pypa/cibuildwheel@v3.1
+
+      - name: Upload wheels artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ runner.os }}-${{ runner.arch }}
+          path: ./wheelhouse/*.whl
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: [build-sdist, build-wheels]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Get sdist
+        uses: actions/download-artifact@v5
+        with:
+          name: Packages
+          path: dist
+      - name: Get wheels
+        uses: actions/download-artifact@v5
+        with:
+          pattern: cibw-wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: 🚢 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
   create-github-release:
     name: Create Release
     needs: build
@@ -71,7 +126,7 @@ jobs:
           release_tag=$(uv run fetch.py --sha ${{ github.event.inputs.submodule_sha || 'main' }})
           echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: artifacts
 
@@ -86,19 +141,3 @@ jobs:
           name: ${{ steps.tag.outputs.release_name }}
           draft: false
           prerelease: false
-
-  create-pypi-release:
-    name: Deploy
-    needs: build
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v6
-      - run: uv build
-        env:
-          MM_SHA: ${{ github.event.inputs.submodule_sha || 'main' }}
-      - name: 🚢 Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ src/mm_test_adapters/version.py
 src/mm_test_adapters/libs/*
 src/mmCoreAndDevices
 *.egg-info/
+wheelhouse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "mm-test-adapters"
 dynamic = ["version"]
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 readme = "README.md"
 dependencies = []
 
@@ -21,3 +21,17 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.cibuildwheel]
+build-verbosity = 1
+build = [
+	"cp39-win_amd64",
+	"cp39-manylinux_x86_64",
+	"cp39-macosx_x86_64",
+	"cp39-macosx_arm64",
+]
+manylinux-x86_64-image = "manylinux_2_28"
+build-frontend = "build[uv]"
+test-command = "pytest {project}/tests -v"
+test-groups = ["test"]
+environment-pass = ["MM_SHA"]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,11 @@ class CustomSdist(sdist):
 
 
 class CustomBdistWheel(bdist_wheel):
+    def get_tag(self):
+        # Get the base tags
+        python_tag, abi_tag, plat_tag = super().get_tag()
+        return python_tag, 'none', plat_tag
+    
     def write_wheelfile(self, wheelfile_base: str, **kwargs: Any) -> None:
         lib_dir = os.path.join(str(self.bdist_dir), "mm_test_adapters", "libs")
         fetch.build_libs(lib_dir)


### PR DESCRIPTION
looks like simply using `uv build` is too simplistic, this uses cibuildwheel, and also sets the python abi tag to `none`