### PR TITLE
fix: more flexible discovery of sources

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include meson.build
 include fetch.py
+include discover_sources.py
 include src/MMConfig_demo.cfg
 
 recursive-include src/mmCoreAndDevices/DeviceAdapters *

--- a/discover_sources.py
+++ b/discover_sources.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""
+Script to dynamically discover source files for Micro-Manager device adapters.
+This script scans a DeviceAdapter directory and returns lists of source files.
+
+While this isn't the recommended approach for a meson.build file, it lets us add some
+degree of flexibility in using a single meson.build file to build multiple different
+versions of mmCoreAndDevices (which may change source over time).
+
+Usage:
+    python3 discover_sources.py <adapter_name>     # List sources for specific adapter
+
+Examples:
+    python3 discover_sources.py DemoCamera         # Show DemoCamera sources
+"""
+
+from pathlib import Path
+
+if __name__ == "__main__":
+    import sys
+
+    # Allow specifying adapter name as command line argument
+    if len(sys.argv) < 2:
+        raise ValueError("Usage: python3 discover_sources.py <adapter_name>")
+
+    adapter_name = sys.argv[1]
+    base_path = Path("src/mmCoreAndDevices/DeviceAdapters")
+    adapter_path = base_path / adapter_name
+    if not adapter_path.exists() or not adapter_path.is_dir():
+        raise ValueError(
+            f"Adapter path {adapter_path} does not exist or is not a directory."
+        )
+    for source in sorted(adapter_path.rglob("*.cpp")):
+        print(source)

--- a/meson.build
+++ b/meson.build
@@ -37,11 +37,16 @@ else
   ]
 endif
 
+# Dynamic source discovery using Python script
+py = find_program('python3')
+
 # DEMO CAMERA -----------------------------
+
+democamera_sources = run_command(py, 'discover_sources.py', 'DemoCamera', check: true).stdout().strip().split('\n')
 
 shared_library(
   'mmgr_dal_DemoCamera',
-  ['src/mmCoreAndDevices/DeviceAdapters/DemoCamera/DemoCamera.cpp'],
+  democamera_sources,
   cpp_args: device_cpp_args,
   dependencies: [mmdevice_dep, winmm_lib],
   install: true,
@@ -49,26 +54,11 @@ shared_library(
 
 # UTILITIES --------------------------------
 
+utilities_sources = run_command(py, 'discover_sources.py', 'Utilities', check: true).stdout().strip().split('\n')
+
 shared_library(
   'mmgr_dal_Utilities',
-  sources: [
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/AutoFocusStage.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/ComboXYStage.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/DAGalvo.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/DAMonochromator.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/DAShutter.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/DATTLStateDevice.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/DAXYStage.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/DAZStage.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/MultiCamera.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/MultiDAStateDevice.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/MultiShutter.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/MultiStage.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/SerialDTRShutter.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/SingleAxisStage.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/StateDeviceShutter.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/Utilities/Utilities.cpp',
-  ],
+  sources: utilities_sources,
   cpp_args: device_cpp_args,
   dependencies: [mmdevice_dep],
   install: true,
@@ -76,11 +66,11 @@ shared_library(
 
 # NOTIFICATION TESTER ----------------------
 
+notificationtester_sources = run_command(py, 'discover_sources.py', 'NotificationTester', check: true).stdout().strip().split('\n')
+
 shared_library(
   'mmgr_dal_NotificationTester',
-  [
-    'src/mmCoreAndDevices/DeviceAdapters/NotificationTester/NotificationTester.cpp',
-  ],
+  notificationtester_sources,
   cpp_args: device_cpp_args,
   dependencies: [mmdevice_dep],
   install: true,
@@ -88,16 +78,11 @@ shared_library(
 
 # SEQUENCE TESTER ------------------------
 
+sequencetester_sources = run_command(py, 'discover_sources.py', 'SequenceTester', check: true).stdout().strip().split('\n')
+
 shared_library(
   'mmgr_dal_SequenceTester',
-  sources: [
-    'src/mmCoreAndDevices/DeviceAdapters/SequenceTester/InterDevice.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/SequenceTester/LoggedSetting.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/SequenceTester/SequenceTester.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/SequenceTester/SettingLogger.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/SequenceTester/TextImage.cpp',
-    'src/mmCoreAndDevices/DeviceAdapters/SequenceTester/TriggerInput.cpp',
-  ],
+  sources: sequencetester_sources,
   cpp_args: device_cpp_args,
   dependencies: [mmdevice_dep, msgpack_dep, boost_dep],
   install: true,


### PR DESCRIPTION
The new `src/mmCoreAndDevices/DeviceAdapters/Utilities/PropertyShutter.cpp` file in mmCoreAndDevices broke builds here because the linker couldn't find it.  This PR dynamically finds sources for each adapter.  It's not "recommended" practice for a meson.build file, but since we're decoupling the meson.build from the device adapters sources (for now) it lets us be a more flexible in using a single meson.build across multiple mmCoreAndDevices shas